### PR TITLE
fix statusbar & system navigation colors and resizeToAvoidBottomInset fix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:project_lagann/controllers/feedback_controller.dart';
 import 'package:project_lagann/models/user.dart';
 import 'package:project_lagann/models/video.dart';
@@ -80,6 +81,13 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+      statusBarBrightness: Brightness.dark,
+      statusBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.light,
+      systemNavigationBarColor: Colors.transparent,
+      systemStatusBarContrastEnforced: false,
+    ));
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (context) => CommentsController()),

--- a/lib/proVideoScreens/proVideo_home_screen.dart
+++ b/lib/proVideoScreens/proVideo_home_screen.dart
@@ -398,6 +398,7 @@ Valhalla calling me""",
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: CustomScrollView(
         slivers: <Widget>[
           SlivAppBar(

--- a/lib/screens/courses_screens/course_item_screen.dart
+++ b/lib/screens/courses_screens/course_item_screen.dart
@@ -49,6 +49,7 @@ class _CourseItemScreenState extends State<CourseItemScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         leading: IconButton(
           onPressed: () {

--- a/lib/screens/courses_screens/courses_all_screen.dart
+++ b/lib/screens/courses_screens/courses_all_screen.dart
@@ -16,6 +16,7 @@ class _CoursesAllScreenState extends State<CoursesAllScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Padding(
         padding: const EdgeInsets.only(bottom: 30),
         child: CustomScrollView(

--- a/lib/screens/courses_screens/courses_purchased_screen.dart
+++ b/lib/screens/courses_screens/courses_purchased_screen.dart
@@ -3,7 +3,6 @@ import 'package:ionicons/ionicons.dart';
 import '../../generated/l10n.dart';
 import '../../utils/constants.dart';
 import '../../widgets/card_widgets/course_item_card.dart';
-import '../../widgets/pro_video_widgets/sliver_appbar.dart';
 
 class CoursesPurchasedScreen extends StatefulWidget {
   const CoursesPurchasedScreen({Key? key}) : super(key: key);
@@ -16,6 +15,7 @@ class _CoursesPurchasedScreenState extends State<CoursesPurchasedScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Padding(
         padding: const EdgeInsets.only(bottom: 30),
         child: CustomScrollView(

--- a/lib/screens/courses_screens/courses_screen.dart
+++ b/lib/screens/courses_screens/courses_screen.dart
@@ -18,6 +18,7 @@ class _CoursesScreenState extends State<CoursesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: CustomScrollView(
         slivers: [
           SlivAppBar(title: S.of(context).navbar_courses),

--- a/lib/screens/home_screens/home_all_screen.dart
+++ b/lib/screens/home_screens/home_all_screen.dart
@@ -12,6 +12,7 @@ class _HomeAllScreenState extends State<HomeAllScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Stack(
         children: [
           PageView.builder(

--- a/lib/screens/home_screens/home_followed_screen.dart
+++ b/lib/screens/home_screens/home_followed_screen.dart
@@ -12,6 +12,7 @@ class _HomeFollowedScreenState extends State<HomeFollowedScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Stack(
         children: [
           PageView.builder(

--- a/lib/screens/home_screens/home_screen.dart
+++ b/lib/screens/home_screens/home_screen.dart
@@ -51,8 +51,9 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: CustomHomeAppBar(
         appBar: AppBar(
             centerTitle: true,
-            elevation: 0.0,
-            backgroundColor: Colors.white.withOpacity(0.0),
+            elevation: 0,
+            backgroundColor: Colors.transparent,
+            bottomOpacity: 0,
             actions: [
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/screens/marathon_screens/detailed_screen.dart
+++ b/lib/screens/marathon_screens/detailed_screen.dart
@@ -33,10 +33,10 @@ class _MarathonDetailedScreenState extends State<MarathonDetailedScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         systemOverlayStyle: const SystemUiOverlayStyle(
           statusBarIconBrightness: Brightness.light,
-          statusBarColor: kBackgroundColor,
         ),
         centerTitle: false,
         titleSpacing: -10,
@@ -65,236 +65,228 @@ class _MarathonDetailedScreenState extends State<MarathonDetailedScreen>
           ),
         ],
       ),
-      body: AnnotatedRegion<SystemUiOverlayStyle>(
-        value: SystemUiOverlayStyle.light
-            .copyWith(systemNavigationBarColor: kSurfaceColor),
-        child: Stack(
-          children: [
-            NestedScrollView(
-              headerSliverBuilder: (context, innerBoxIsScrolled) => [
-                SliverList(
-                  delegate: SliverChildListDelegate(
-                    [
-                      FittedBox(
-                        fit: BoxFit.fitHeight,
-                        child: Padding(
-                          padding: const EdgeInsets.only(left: 16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                crossAxisAlignment: CrossAxisAlignment.start,
+      body: Stack(
+        children: [
+          NestedScrollView(
+            headerSliverBuilder: (context, innerBoxIsScrolled) => [
+              SliverList(
+                delegate: SliverChildListDelegate(
+                  [
+                    FittedBox(
+                      fit: BoxFit.fitHeight,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(10),
+                                  child: Image.network(
+                                    widget.marathonModel.previewPhoto.first,
+                                    height: 356,
+                                    width: 238,
+                                    fit: BoxFit.cover,
+                                  ),
+                                ),
+                                SizedBox(
+                                  width:
+                                      MediaQuery.of(context).size.width * 0.4,
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    children: [
+                                      DetailedScreenItem(
+                                        Ionicons.person_outline,
+                                        S.of(context).marathon_detailed_item1,
+                                        widget.marathonModel
+                                                .participantsQantyti ??
+                                            "253",
+                                      ),
+                                      DetailedScreenItem(
+                                        Ionicons.layers_outline,
+                                        S.of(context).marathon_detailed_item2,
+                                        widget.marathonModel.category,
+                                      ),
+                                      DetailedScreenItem(
+                                        Ionicons.extension_puzzle_outline,
+                                        S.of(context).marathon_detailed_item3,
+                                        widget.marathonModel.stagesQantyti ??
+                                            "12/15",
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.only(top: 8, bottom: 16),
+                              child: Row(
                                 children: [
-                                  ClipRRect(
-                                    borderRadius: BorderRadius.circular(10),
-                                    child: Image.network(
-                                      widget.marathonModel.previewPhoto.first,
-                                      height: 356,
-                                      width: 238,
-                                      fit: BoxFit.cover,
+                                  InkWell(
+                                    onTap: () {},
+                                    child: Container(
+                                      width: 60,
+                                      height: 40,
+                                      decoration: BoxDecoration(
+                                        color: kPrimaryColor,
+                                        borderRadius: BorderRadius.circular(10),
+                                      ),
+                                      child: const Icon(
+                                        Ionicons.notifications_outline,
+                                        color: kGreyColor,
+                                        size: kIconSize8,
+                                      ),
                                     ),
                                   ),
-                                  SizedBox(
-                                    width:
-                                        MediaQuery.of(context).size.width * 0.4,
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.center,
-                                      children: [
-                                        DetailedScreenItem(
-                                          Ionicons.person_outline,
-                                          S.of(context).marathon_detailed_item1,
-                                          widget.marathonModel
-                                                  .participantsQantyti ??
-                                              "253",
-                                        ),
-                                        DetailedScreenItem(
-                                          Ionicons.layers_outline,
-                                          S.of(context).marathon_detailed_item2,
-                                          widget.marathonModel.category,
-                                        ),
-                                        DetailedScreenItem(
-                                          Ionicons.extension_puzzle_outline,
-                                          S.of(context).marathon_detailed_item3,
-                                          widget.marathonModel.stagesQantyti ??
-                                              "12/15",
-                                        ),
-                                      ],
-                                    ),
+                                  const SizedBox(
+                                    width: 16,
                                   ),
-                                ],
-                              ),
-                              Padding(
-                                padding:
-                                    const EdgeInsets.only(top: 8, bottom: 16),
-                                child: Row(
-                                  children: [
-                                    InkWell(
-                                      onTap: () {},
-                                      child: Container(
-                                        width: 60,
-                                        height: 40,
-                                        decoration: BoxDecoration(
+                                  InkWell(
+                                    onTap: () {},
+                                    child: Container(
+                                      width: 304,
+                                      height: 40,
+                                      alignment: Alignment.center,
+                                      decoration: BoxDecoration(
                                           color: kPrimaryColor,
                                           borderRadius:
-                                              BorderRadius.circular(10),
-                                        ),
-                                        child: const Icon(
-                                          Ionicons.notifications_outline,
-                                          color: kGreyColor,
-                                          size: kIconSize8,
-                                        ),
-                                      ),
-                                    ),
-                                    const SizedBox(
-                                      width: 16,
-                                    ),
-                                    InkWell(
-                                      onTap: () {},
-                                      child: Container(
-                                        width: 304,
-                                        height: 40,
-                                        alignment: Alignment.center,
-                                        decoration: BoxDecoration(
-                                            color: kPrimaryColor,
-                                            borderRadius:
-                                                BorderRadius.circular(10)),
-                                        child: Text(
-                                          "START GAME - ${widget.marathonModel.price}",
-                                          style: kSubtitle2.copyWith(
-                                            color: kWhiteColor,
-                                            letterSpacing: 1.25,
-                                          ),
+                                              BorderRadius.circular(10)),
+                                      child: Text(
+                                        "START GAME - ${widget.marathonModel.price}",
+                                        style: kSubtitle2.copyWith(
+                                          color: kWhiteColor,
+                                          letterSpacing: 1.25,
                                         ),
                                       ),
                                     ),
-                                  ],
-                                ),
-                              ),
-                              Row(
-                                children: [
-                                  SizedBox(
-                                    width: 288,
-                                    child: Text(
-                                      widget.marathonModel.description,
-                                      style: kHeadline4.copyWith(
-                                          color: kWhiteColor),
-                                      overflow: TextOverflow.ellipsis,
-                                    ),
-                                  ),
-                                  Text(
-                                    DateFormat("dd MMM yyyy")
-                                        .format(widget.marathonModel.startDate),
-                                    style: kBody2TS.copyWith(color: kGreyColor),
                                   ),
                                 ],
                               ),
-                              Row(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    "Created by ",
+                            ),
+                            Row(
+                              children: [
+                                SizedBox(
+                                  width: 288,
+                                  child: Text(
+                                    widget.marathonModel.description,
                                     style:
-                                        kSubtitle2.copyWith(color: kWhiteColor),
+                                        kHeadline4.copyWith(color: kWhiteColor),
+                                    overflow: TextOverflow.ellipsis,
                                   ),
-                                  Text(
-                                    "Andrew Pech",
-                                    style: kSubtitle2.copyWith(
-                                        color: kPrimaryColor),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 12),
-                        child: Container(
-                          width: MediaQuery.of(context).size.width,
-                          height: 2,
-                          color: kSurfaceColor,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                SliverOverlapAbsorber(
-                  handle:
-                      NestedScrollView.sliverOverlapAbsorberHandleFor(context),
-                  sliver: SliverAppBar(
-                    elevation: 1,
-                    shadowColor: kSurfaceColor,
-                    forceElevated: true,
-                    automaticallyImplyLeading: false,
-                    toolbarHeight: 0,
-                    pinned: true,
-                    bottom: PreferredSize(
-                      preferredSize: const Size(100, 36),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                        ),
-                        child: TabBar(
-                          controller: _tabController,
-                          splashBorderRadius: BorderRadius.circular(5),
-                          indicatorColor: kPrimaryColor,
-                          indicatorWeight: 4,
-                          indicatorSize: TabBarIndicatorSize.tab,
-                          indicator:
-                              const CustomTabIndicator(color: kPrimaryColor),
-                          tabs: [
-                            SizedBox(
-                              height: 32,
-                              child: Tab(
-                                child: Text(
-                                  S.of(context).marathon_tab_bar_about,
-                                  style:
-                                      kHeadline5.copyWith(color: kWhiteColor),
                                 ),
-                              ),
+                                Text(
+                                  DateFormat("dd MMM yyyy")
+                                      .format(widget.marathonModel.startDate),
+                                  style: kBody2TS.copyWith(color: kGreyColor),
+                                ),
+                              ],
                             ),
-                            SizedBox(
-                              height: 32,
-                              child: Tab(
-                                child: Text(
-                                  S.of(context).marathon_tab_bar_video,
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              children: [
+                                Text(
+                                  "Created by ",
                                   style:
-                                      kHeadline5.copyWith(color: kWhiteColor),
+                                      kSubtitle2.copyWith(color: kWhiteColor),
                                 ),
-                              ),
-                            ),
-                            SizedBox(
-                              height: 32,
-                              child: Tab(
-                                child: Text(
-                                  S.of(context).marathon_tab_bar_statistics,
+                                Text(
+                                  "Andrew Pech",
                                   style:
-                                      kHeadline5.copyWith(color: kWhiteColor),
+                                      kSubtitle2.copyWith(color: kPrimaryColor),
                                 ),
-                              ),
+                              ],
                             ),
                           ],
                         ),
                       ),
                     ),
-                  ),
-                ),
-              ],
-              body: Padding(
-                padding: const EdgeInsets.only(top: 52),
-                child: TabBarView(
-                  controller: _tabController,
-                  children: const [
-                    TabBarAbout(),
-                    TabBarVideo(),
-                    TabBarStatistics(),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: Container(
+                        width: MediaQuery.of(context).size.width,
+                        height: 2,
+                        color: kSurfaceColor,
+                      ),
+                    ),
                   ],
                 ),
               ),
+              SliverOverlapAbsorber(
+                handle:
+                    NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                sliver: SliverAppBar(
+                  elevation: 1,
+                  shadowColor: kSurfaceColor,
+                  forceElevated: true,
+                  automaticallyImplyLeading: false,
+                  toolbarHeight: 0,
+                  pinned: true,
+                  bottom: PreferredSize(
+                    preferredSize: const Size(100, 36),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                      ),
+                      child: TabBar(
+                        controller: _tabController,
+                        splashBorderRadius: BorderRadius.circular(5),
+                        indicatorColor: kPrimaryColor,
+                        indicatorWeight: 4,
+                        indicatorSize: TabBarIndicatorSize.tab,
+                        indicator:
+                            const CustomTabIndicator(color: kPrimaryColor),
+                        tabs: [
+                          SizedBox(
+                            height: 32,
+                            child: Tab(
+                              child: Text(
+                                S.of(context).marathon_tab_bar_about,
+                                style: kHeadline5.copyWith(color: kWhiteColor),
+                              ),
+                            ),
+                          ),
+                          SizedBox(
+                            height: 32,
+                            child: Tab(
+                              child: Text(
+                                S.of(context).marathon_tab_bar_video,
+                                style: kHeadline5.copyWith(color: kWhiteColor),
+                              ),
+                            ),
+                          ),
+                          SizedBox(
+                            height: 32,
+                            child: Tab(
+                              child: Text(
+                                S.of(context).marathon_tab_bar_statistics,
+                                style: kHeadline5.copyWith(color: kWhiteColor),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            body: Padding(
+              padding: const EdgeInsets.only(top: 52),
+              child: TabBarView(
+                controller: _tabController,
+                children: const [
+                  TabBarAbout(),
+                  TabBarVideo(),
+                  TabBarStatistics(),
+                ],
+              ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/marathon_screens/home_screen.dart
+++ b/lib/screens/marathon_screens/home_screen.dart
@@ -134,6 +134,7 @@ class _MarathonHomeScreenState extends State<MarathonHomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: CustomScrollView(
         slivers: [
           SlivAppBar(

--- a/lib/screens/marathon_screens/see_all_screen.dart
+++ b/lib/screens/marathon_screens/see_all_screen.dart
@@ -14,6 +14,7 @@ class SeeAllScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: CustomScrollView(
         slivers: [
           SlivAppBar(

--- a/lib/screens/root_screen.dart
+++ b/lib/screens/root_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:ionicons/ionicons.dart';
 // localization
 import 'package:project_lagann/utils/constants.dart';
@@ -20,10 +19,7 @@ class _RootScreenState extends State<RootScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: AnnotatedRegion<SystemUiOverlayStyle>(
-          value: SystemUiOverlayStyle.light
-              .copyWith(statusBarColor: kBackgroundColor),
-          child: SafeArea(child: pages[_currentBottomNavBarIndex])),
+      body: SafeArea(child: pages[_currentBottomNavBarIndex]),
       bottomNavigationBar: BottomNavigationBar(
         selectedFontSize: 10,
         unselectedFontSize: 10,


### PR DESCRIPTION
* fixed system navigation bar, system status bar colors, from ??? to transparent
* added resizeToAvoidBottomInset: false for all scaffolds
	modified:   lib/main.dart
	modified:   lib/proVideoScreens/proVideo_home_screen.dart
	modified:   lib/screens/courses_screens/course_item_screen.dart
	modified:   lib/screens/courses_screens/courses_all_screen.dart
	modified:   lib/screens/courses_screens/courses_purchased_screen.dart
	modified:   lib/screens/courses_screens/courses_screen.dart
	modified:   lib/screens/home_screens/home_all_screen.dart
	modified:   lib/screens/home_screens/home_followed_screen.dart
* set transparent appbar
	modified:   lib/screens/home_screens/home_screen.dart
	modified:   lib/screens/marathon_screens/detailed_screen.dart
	modified:   lib/screens/marathon_screens/home_screen.dart
	modified:   lib/screens/marathon_screens/see_all_screen.dart
	modified:   lib/screens/root_screen.dart